### PR TITLE
chore: group dependabot updates and pin actions to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: npm
-    directory: /
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-        interval: monthly
+      interval: "monthly"
+    groups:
+      patch:
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary

Standardize Dependabot grouping rules and pin GitHub Actions to commit hashes.

- Add `patch` group (`update-types: ["patch"]`) for non-actions / non-terraform ecosystems so that patch-level updates land in a single PR.
- Group all GitHub Actions into `all-actions` and Terraform providers into `all-providers` (where applicable).
- Pin all GitHub Actions referenced in `.github/workflows/*.yml` to commit hashes using [pinact](https://github.com/suzuki-shunsuke/pinact). The version comment after each hash lets Dependabot continue to bump them.

## Test plan

- [ ] Confirm Dependabot UI accepts the new config (no errors on next scheduled run)
- [ ] Confirm existing workflows still pass